### PR TITLE
Fixing the USDailyDataPoint graphql schema to match the REST endpoint

### DIFF
--- a/src/schema.js
+++ b/src/schema.js
@@ -64,13 +64,22 @@ const typeDefs = gql`
 
   type USDailyDataPoint implements DataPoint {
     date: Date
-    statesReporting: Int
-    positives: Int
-    negatives: Int
-    positivesPlusNegatives: Int
+    states: Int
+    positive: Int
+    negative: Int
+    posNeg: Int
     pending: Int
-    deaths: Int
+    hospitalized: Int
+    death: Int
     total: Int
+    hash: String
+    dateChecked: Date
+    totalTestResults: Int
+    deathIncrease: Int
+    hospitalizedIncrease: Int
+    negativeIncrease: Int
+    positiveIncrease: Int
+    totalTestResultsIncrease: Int
   }
 
   type USTotalDataPoint implements DataPoint {


### PR DESCRIPTION
As reported here: https://github.com/COVID19Tracking/covid-tracking-api/issues/23 -- the graphql schema doesn't match the REST schema, so this data isn't showing properly for the `usDailyData` query. 

I haven't actually been able to run the app, so I can't actually verify that this works, but figured I'd put it up here anyway