### PR TITLE
Fix CovidStat:hospitalized in schema.js

### DIFF
--- a/src/schema.js
+++ b/src/schema.js
@@ -18,6 +18,7 @@ const typeDefs = gql`
     positive: Int
     negative: Int
     pending: Int
+    hospitalized: Int
     death: Int
     dateModified: Date
     dateChecked: Date


### PR DESCRIPTION
The GraphQL specification was missing the entry.

Disclosure. I consider myself an advance GraphQL consumer but have limited experience implementing so there might be other issues at hand to get it to work.